### PR TITLE
Add line highlighting support

### DIFF
--- a/highlighting.go
+++ b/highlighting.go
@@ -186,36 +186,38 @@ func (r *HTMLRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, no
 	}
 	language := n.Language(source)
 
-	highlightLinesIdx := -1
-
-	for idx, char := range language {
-		if char == '{' {
-			highlightLinesIdx = idx
-			break
-		}
-	}
-
-	var linesStr []string
 	doHlLines := false
-	if highlightLinesIdx > 0 && language[len(language)-1] == '}' {
-		doHlLines = true
-		rangesStr := string(language[highlightLinesIdx+1:len(language)-1])
-		linesStr = strings.Split(rangesStr, ",")
-	}
 	hlRanges := [][2]int{}
-	for _, l := range linesStr {
-		num, err := strconv.Atoi(l)
-		if err != nil {
-			doHlLines = false
-			break
-		}
-		hlRanges = append(hlRanges, [2]int{num, num})
-	}
-
 	chromaFormatterOptions := r.FormatOptions
-	if doHlLines {
-		language = language[:highlightLinesIdx]
-		chromaFormatterOptions = append(chromaFormatterOptions, chromahtml.HighlightLines(hlRanges))
+	if language != nil {
+		highlightLinesIdx := -1
+
+		for idx, char := range language {
+			if char == '{' {
+				highlightLinesIdx = idx
+				break
+			}
+		}
+
+		var linesStr []string
+		if highlightLinesIdx > 0 && language[len(language)-1] == '}' {
+			doHlLines = true
+			rangesStr := string(language[highlightLinesIdx+1 : len(language)-1])
+			linesStr = strings.Split(rangesStr, ",")
+		}
+		for _, l := range linesStr {
+			num, err := strconv.Atoi(l)
+			if err != nil {
+				doHlLines = false
+				break
+			}
+			hlRanges = append(hlRanges, [2]int{num, num})
+		}
+
+		if doHlLines {
+			language = language[:highlightLinesIdx]
+			chromaFormatterOptions = append(chromaFormatterOptions, chromahtml.HighlightLines(hlRanges))
+		}
 	}
 
 	var lexer chroma.Lexer

--- a/highlighting.go
+++ b/highlighting.go
@@ -101,7 +101,7 @@ func WithHTMLOptions(opts ...html.Option) Option {
 
 const optStyle renderer.OptionName = "HighlightingStyle"
 const highlightLinesAttrName = "hl_lines"
-const styleAttrName = "style"
+const styleAttrName = "hl_style"
 const nohlAttrName = "nohl"
 
 type withStyle struct {

--- a/highlighting.go
+++ b/highlighting.go
@@ -102,6 +102,7 @@ func WithHTMLOptions(opts ...html.Option) Option {
 const optStyle renderer.OptionName = "HighlightingStyle"
 const highlightLinesAttrName = "hl_lines"
 const styleAttrName = "style"
+const nohlAttrName = "nohl"
 
 type withStyle struct {
 	value string
@@ -220,6 +221,7 @@ func (r *HTMLRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, no
 
 	chromaFormatterOptions := r.FormatOptions
 	style := styles.Get(r.Style)
+	nohl := true
 
 	attrs, language := getAttrbite(n, language)
 	if attrs != nil {
@@ -250,6 +252,9 @@ func (r *HTMLRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, no
 			styleStr := string([]byte(styleAttr.([]uint8)))
 			style = styles.Get(styleStr)
 		}
+		if _, hasNohlAttr := attrs[nohlAttrName]; hasNohlAttr {
+			nohl = true
+		}
 	}
 
 	var lexer chroma.Lexer
@@ -257,7 +262,7 @@ func (r *HTMLRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, no
 		lexer = lexers.Get(string(language))
 	}
 	rendered := false
-	if lexer != nil {
+	if !nohl && lexer != nil {
 		if style == nil {
 			style = styles.Fallback
 		}

--- a/highlighting.go
+++ b/highlighting.go
@@ -221,7 +221,7 @@ func (r *HTMLRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, no
 
 	chromaFormatterOptions := r.FormatOptions
 	style := styles.Get(r.Style)
-	nohl := true
+	nohl := false
 
 	attrs, language := getAttrbite(n, language)
 	if attrs != nil {

--- a/highlighting_test.go
+++ b/highlighting_test.go
@@ -2,7 +2,6 @@ package highlighting
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 

--- a/highlighting_test.go
+++ b/highlighting_test.go
@@ -2,10 +2,12 @@ package highlighting
 
 import (
 	"bytes"
-	chromahtml "github.com/alecthomas/chroma/formatters/html"
-	"github.com/yuin/goldmark"
+	"fmt"
 	"strings"
 	"testing"
+
+	chromahtml "github.com/alecthomas/chroma/formatters/html"
+	"github.com/yuin/goldmark"
 )
 
 func TestHighlighting(t *testing.T) {
@@ -136,5 +138,36 @@ func main() {
 `) {
 		t.Error("failed to render HTML")
 	}
+}
 
+func TestHighlighting3(t *testing.T) {
+	markdown := goldmark.New(
+		goldmark.WithExtensions(
+			Highlighting,
+		),
+	)
+	var buffer bytes.Buffer
+	if err := markdown.Convert([]byte(`
+Title
+=======
+
+`+"```"+`cpp{hl_lines=[1,2]}
+#include <iostream>
+int main() {
+    std::cout<< "hello" << std::endl;
+}
+`+"```"+`
+`), &buffer); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
+<h1>Title</h1>
+<pre style="background-color:#fff"><span style="display:block;width:100%;background-color:#e5e5e5"><span style="color:#999;font-weight:bold;font-style:italic">#</span><span style="color:#999;font-weight:bold;font-style:italic">include</span> <span style="color:#999;font-weight:bold;font-style:italic">&lt;iostream&gt;</span><span style="color:#999;font-weight:bold;font-style:italic">
+</span></span><span style="display:block;width:100%;background-color:#e5e5e5"><span style="color:#999;font-weight:bold;font-style:italic"></span><span style="color:#458;font-weight:bold">int</span> <span style="color:#900;font-weight:bold">main</span>() {
+</span>    std<span style="color:#000;font-weight:bold">:</span><span style="color:#000;font-weight:bold">:</span>cout<span style="color:#000;font-weight:bold">&lt;</span><span style="color:#000;font-weight:bold">&lt;</span> <span style="color:#d14"></span><span style="color:#d14">&#34;</span><span style="color:#d14">hello</span><span style="color:#d14">&#34;</span> <span style="color:#000;font-weight:bold">&lt;</span><span style="color:#000;font-weight:bold">&lt;</span> std<span style="color:#000;font-weight:bold">:</span><span style="color:#000;font-weight:bold">:</span>endl;
+}
+</pre>
+`) {
+		t.Error("failed to render HTML")
+	}
 }


### PR DESCRIPTION
Extend the fenced code highlighting syntax

Use the syntax like

~~~
```cpp{1,2,3}
```
~~~

To highlight the lines of 1, 2 and 3. 