### PR TITLE
DO NOT MERGE: Add LineNumbersInTable in table test

### DIFF
--- a/highlighting_test.go
+++ b/highlighting_test.go
@@ -205,7 +205,7 @@ func TestHighlightingHlLines(t *testing.T) {
 
 	for i, test := range []struct {
 		attributes string
-		expect   []int
+		expect     []int
 	}{
 		{`hl_lines=["2"]`, []int{2}},
 		{`hl_lines=["2-3",5],linenostart=5`, []int{2, 3, 5}},
@@ -240,5 +240,32 @@ LINE8
 			}
 		})
 	}
+
+}
+
+func TestHighlightingLineNumbersInTable(t *testing.T) {
+	markdown := goldmark.New(
+		goldmark.WithExtensions(
+			NewHighlighting(
+				WithFormatOptions(
+					//chromahtml.PreventSurroundingPre(),
+					chromahtml.WithClasses(),
+					chromahtml.LineNumbersInTable(),
+				),
+			),
+		),
+	)
+
+	content := "```bash {linenos=true}\n" + `
+echo "Hello"
+` + "\n```"
+
+	var buffer bytes.Buffer
+
+	if err := markdown.Convert([]byte(content), &buffer); err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(buffer.String())
 
 }


### PR DESCRIPTION
Just added this problem to illustrate a problem I hadn't thought about.

When LineNumbersInTable is set and linenos is enabled, the output is wrapped in a table and you get multiple pre's. To cut a long story short, the wrapper logic does not hold water anymore. And having line numbers in a table is a very useful feature.

I will try to get a PR merged in Chroma that allows configuring with a func that allows a custom "pre", which I guess is the only way to fix this without ugly string-replace.
