### PR TITLE
Add GuessSyntax option

### DIFF
--- a/highlighting_test.go
+++ b/highlighting_test.go
@@ -304,3 +304,29 @@ LINE1
 		})
 	}
 }
+
+func TestHighlightingGuessLanguage(t *testing.T) {
+	markdown := goldmark.New(
+		goldmark.WithExtensions(
+			NewHighlighting(
+				WithGuessLanguage(true),
+				WithFormatOptions(
+					chromahtml.WithClasses(true),
+					chromahtml.WithLineNumbers(true),
+				),
+			),
+		),
+	)
+	var buffer bytes.Buffer
+	if err := markdown.Convert([]byte("```"+`
+LINE	
+`+"```"), &buffer); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
+<pre class="chroma"><span class="ln">1</span>LINE	
+</pre>
+`) {
+		t.Errorf("render mismatch, got\n%s", buffer.String())
+	}
+}


### PR DESCRIPTION
Note that there isn't much guessing going on in Chroma, but this is in line with its API.

The use for this is currently people who want all code blocks to have that "Chroma look", with line numbers etc.

See https://github.com/gohugoio/hugo/issues/6565