### PR TITLE
Use chroma.Coalesce

### DIFF
--- a/highlighting.go
+++ b/highlighting.go
@@ -472,6 +472,7 @@ func (r *HTMLRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, no
 			}
 			language = []byte(strings.ToLower(lexer.Config().Name))
 		}
+		lexer = chroma.Coalesce(lexer)
 
 		iterator, err := lexer.Tokenise(nil, buffer.String())
 		if err == nil {

--- a/highlighting_test.go
+++ b/highlighting_test.go
@@ -66,7 +66,7 @@ Title
 
 	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
 <h1>Title</h1>
-<div class="highlight"><pre class="chroma"><span class="ln">1</span><span class="kd">func</span> <span class="nf">main</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span>
+<div class="highlight"><pre class="chroma"><span class="ln">1</span><span class="kd">func</span> <span class="nf">main</span><span class="p">()</span> <span class="p">{</span>
 <span class="ln">2</span>    <span class="nx">fmt</span><span class="p">.</span><span class="nf">Println</span><span class="p">(</span><span class="s">&#34;ok&#34;</span><span class="p">)</span>
 <span class="ln">3</span><span class="p">}</span>
 </pre></div>
@@ -189,9 +189,9 @@ int main() {
 	}
 	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
 <h1>Title</h1>
-<pre style="background-color:#fff"><span style="display:block;width:100%;background-color:#e5e5e5"><span style="color:#999;font-weight:bold;font-style:italic">#</span><span style="color:#999;font-weight:bold;font-style:italic">include</span> <span style="color:#999;font-weight:bold;font-style:italic">&lt;iostream&gt;</span><span style="color:#999;font-weight:bold;font-style:italic">
+<pre style="background-color:#fff"><span style="display:block;width:100%;background-color:#e5e5e5"><span style="color:#999;font-weight:bold;font-style:italic">#include</span> <span style="color:#999;font-weight:bold;font-style:italic">&lt;iostream&gt;</span><span style="color:#999;font-weight:bold;font-style:italic">
 </span></span><span style="display:block;width:100%;background-color:#e5e5e5"><span style="color:#999;font-weight:bold;font-style:italic"></span><span style="color:#458;font-weight:bold">int</span> <span style="color:#900;font-weight:bold">main</span>() {
-</span>    std<span style="color:#000;font-weight:bold">:</span><span style="color:#000;font-weight:bold">:</span>cout<span style="color:#000;font-weight:bold">&lt;</span><span style="color:#000;font-weight:bold">&lt;</span> <span style="color:#d14"></span><span style="color:#d14">&#34;</span><span style="color:#d14">hello</span><span style="color:#d14">&#34;</span> <span style="color:#000;font-weight:bold">&lt;</span><span style="color:#000;font-weight:bold">&lt;</span> std<span style="color:#000;font-weight:bold">:</span><span style="color:#000;font-weight:bold">:</span>endl;
+</span>    std<span style="color:#000;font-weight:bold">::</span>cout<span style="color:#000;font-weight:bold">&lt;&lt;</span> <span style="color:#d14">&#34;hello&#34;</span> <span style="color:#000;font-weight:bold">&lt;&lt;</span> std<span style="color:#000;font-weight:bold">::</span>endl;
 }
 </pre>
 `) {
@@ -325,6 +325,44 @@ LINE
 	}
 	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
 <pre class="chroma"><span class="ln">1</span>LINE	
+</pre>
+`) {
+		t.Errorf("render mismatch, got\n%s", buffer.String())
+	}
+}
+
+func TestCoalesceNeeded(t *testing.T) {
+	markdown := goldmark.New(
+		goldmark.WithExtensions(
+			NewHighlighting(
+				// WithGuessLanguage(true),
+				WithFormatOptions(
+					chromahtml.WithClasses(true),
+					chromahtml.WithLineNumbers(true),
+				),
+			),
+		),
+	)
+	var buffer bytes.Buffer
+	if err := markdown.Convert([]byte("```http"+`
+GET /foo HTTP/1.1
+Content-Type: application/json
+User-Agent: foo
+
+{
+  "hello": "world"
+}
+`+"```"), &buffer); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
+<pre class="chroma"><span class="ln">1</span><span class="nf">GET</span> <span class="nn">/foo</span> <span class="kr">HTTP</span><span class="o">/</span><span class="m">1.1</span>
+<span class="ln">2</span><span class="n">Content-Type</span><span class="o">:</span> <span class="l">application/json</span>
+<span class="ln">3</span><span class="n">User-Agent</span><span class="o">:</span> <span class="l">foo</span>
+<span class="ln">4</span>
+<span class="ln">5</span><span class="p">{</span>
+<span class="ln">6</span>  <span class="nt">&#34;hello&#34;</span><span class="p">:</span> <span class="s2">&#34;world&#34;</span>
+<span class="ln">7</span><span class="p">}</span>
 </pre>
 `) {
 		t.Errorf("render mismatch, got\n%s", buffer.String())


### PR DESCRIPTION
This is identical to https://github.com/gohugoio/hugo/issues/6877
`chroma.Coalesce` is needed to render codes in some langs (http etc) properly.

This fix leads to change expected html of `TestHighlighting` and `TestHighlighting3`.
But these are trivial because unnecessary spans are removed.