### PR TITLE
Update chroma

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/GeertJohan/go.rice v1.0.0 // indirect
-	github.com/alecthomas/chroma v0.7.1
+	github.com/alecthomas/chroma v0.7.2-0.20200305040604-4f3623dce67a
 	github.com/alecthomas/kong-hcl v0.1.8-0.20190615233001-b21fea9723c8 // indirect
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/gorilla/csrf v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/alecthomas/chroma v0.7.0 h1:z+0HgTUmkpRDRz0SRSdMaqOLfJV4F+N1FPDZUZIDU
 github.com/alecthomas/chroma v0.7.0/go.mod h1:1U/PfCsTALWWYHDnsIQkxEBM0+6LLe0v8+RSVMOwxeY=
 github.com/alecthomas/chroma v0.7.1 h1:G1i02OhUbRi2nJxcNkwJaY/J1gHXj9tt72qN6ZouLFQ=
 github.com/alecthomas/chroma v0.7.1/go.mod h1:gHw09mkX1Qp80JlYbmN9L3+4R5o6DJJ3GRShh+AICNc=
+github.com/alecthomas/chroma v0.7.2-0.20200305040604-4f3623dce67a h1:3v1NrYWWqp2S72e4HLgxKt83B3l0lnORDholH/ihoMM=
+github.com/alecthomas/chroma v0.7.2-0.20200305040604-4f3623dce67a/go.mod h1:fv5SzZPFJbwp2NXJWpFIX7DZS4HgV1K4ew4Pc2OZD9s=
 github.com/alecthomas/colour v0.0.0-20160524082231-60882d9e2721 h1:JHZL0hZKJ1VENNfmXvHbgYlbUOvpzYzvy2aZU5gXVeo=
 github.com/alecthomas/colour v0.0.0-20160524082231-60882d9e2721/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8qTHF68zU0=
 github.com/alecthomas/kong v0.1.17-0.20190424132513-439c674f7ae0/go.mod h1:+inYUSluD+p4L8KdviBSgzcqEjUQOfC5fQDRFuc36lI=


### PR DESCRIPTION
Upstream `chroma` had trouble with windows' style line ending (=`\r\n`), resulting in broken htmls
The issue was fixed with https://github.com/alecthomas/chroma/pull/336 .
This update will fix downstream issue (https://github.com/gohugoio/hugo/issues/6596)

### Example
With an attached [python-snippet.txt](https://github.com/yuin/goldmark-highlighting/files/4301572/python-snippet.txt)


Actual result (note `</span>yle...` just after `</h1>`)
```html
<h1>Title</h1>
</span>yle="background-color:#fff"><span style="color:#998;font-style:italic"># launch program
<span style="color:#000;font-weight:bold">def</span> <span style="color:#900;font-weight:bold">main</span>():
    <span style="color:#000;font-weight:bold">print</span>(<span style="color:#099">1</span>)
</pre>
```

Expected result
```html
<h1>Title</h1>
<pre style="background-color:#fff"><span style="color:#998;font-style:italic"># launch program</span>
<span style="color:#000;font-weight:bold">def</span> <span style="color:#900;font-weight:bold">main</span>():
    <span style="color:#000;font-weight:bold">print</span>(<span style="color:#099">1</span>)
</pre>
```