### PR TITLE
Allow for tabindex="0" in <pre> wrapper since chroma v0.9.2

### DIFF
--- a/highlighting_test.go
+++ b/highlighting_test.go
@@ -66,7 +66,7 @@ Title
 		t.Fatal(err)
 	}
 
-	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
+	if strings.TrimSpace(strings.Replace(buffer.String(), `<pre tabindex="0"`, `<pre`, 1)) != strings.TrimSpace(`
 <h1>Title</h1>
 <div class="highlight"><pre class="chroma"><span class="ln">1</span><span class="kd">func</span> <span class="nf">main</span><span class="p">()</span> <span class="p">{</span>
 <span class="ln">2</span>    <span class="nx">fmt</span><span class="p">.</span><span class="nf">Println</span><span class="p">(</span><span class="s">&#34;ok&#34;</span><span class="p">)</span>
@@ -196,7 +196,7 @@ int main() {
 `), &buffer); err != nil {
 		t.Fatal(err)
 	}
-	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
+	if strings.TrimSpace(strings.Replace(buffer.String(), `<pre tabindex="0"`, `<pre`, 1)) != strings.TrimSpace(`
 <h1>Title</h1>
 <pre style="background-color:#fff"><span style="display:block;width:100%;background-color:#e5e5e5"><span style="color:#999;font-weight:bold;font-style:italic">#include</span> <span style="color:#999;font-weight:bold;font-style:italic">&lt;iostream&gt;</span><span style="color:#999;font-weight:bold;font-style:italic">
 </span></span><span style="display:block;width:100%;background-color:#e5e5e5"><span style="color:#999;font-weight:bold;font-style:italic"></span><span style="color:#458;font-weight:bold">int</span> <span style="color:#900;font-weight:bold">main</span>() {
@@ -294,7 +294,7 @@ Title
 		t.Fatal(err)
 	}
 
-	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
+	if strings.TrimSpace(strings.Replace(buffer.String(), `<pre tabindex="0"`, `<pre`, 1)) != strings.TrimSpace(`
 <h1>Title</h1>
 <div class="highlight"><pre class="chroma"><span class="ln">1</span><span class="kd">func</span> <span class="nf">main</span><span class="p">()</span> <span class="p">{</span>
 <span class="ln">2</span>    <span class="nx">fmt</span><span class="p">.</span><span class="nf">Println</span><span class="p">(</span><span class="s">&#34;ok&#34;</span><span class="p">)</span>
@@ -499,7 +499,7 @@ LINE
 `+"```"), &buffer); err != nil {
 		t.Fatal(err)
 	}
-	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
+	if strings.TrimSpace(strings.Replace(buffer.String(), `<pre tabindex="0"`, `<pre`, 1)) != strings.TrimSpace(`
 <pre class="chroma"><span class="ln">1</span>LINE	
 </pre>
 `) {
@@ -531,7 +531,7 @@ User-Agent: foo
 `+"```"), &buffer); err != nil {
 		t.Fatal(err)
 	}
-	if strings.TrimSpace(buffer.String()) != strings.TrimSpace(`
+	if strings.TrimSpace(strings.Replace(buffer.String(), `<pre tabindex="0"`, `<pre`, 1)) != strings.TrimSpace(`
 <pre class="chroma"><span class="ln">1</span><span class="nf">GET</span> <span class="nn">/foo</span> <span class="kr">HTTP</span><span class="o">/</span><span class="m">1.1</span>
 <span class="ln">2</span><span class="n">Content-Type</span><span class="o">:</span> <span class="l">application/json</span>
 <span class="ln">3</span><span class="n">User-Agent</span><span class="o">:</span> <span class="l">foo</span>


### PR DESCRIPTION
This is my fix for [Debian Bug#997567](https://bugs.debian.org/997567) where golang-github-yuin-goldmark-highlighting "fails to build from source" (FTBFS) with chroma v0.9.2 and up in which the `tabindex="0"` attribute is added to the `<pre>` tag, causing mismatch in the rendered HTML in highlighting_test.go as seen below:

```
$ go test ./...
--- FAIL: TestHighlighting (0.00s)
    highlighting_test.go:76: failed to render HTML
--- FAIL: TestHighlighting3 (0.00s)
    highlighting_test.go:207: failed to render HTML
--- FAIL: TestHighlightingCustom (0.00s)
    highlighting_test.go:304: failed to render HTML
--- FAIL: TestHighlightingGuessLanguage (0.00s)
    highlighting_test.go:506: render mismatch, got
        <pre tabindex="0" class="chroma"><span class="ln">1</span>LINE	
        </pre>
--- FAIL: TestCoalesceNeeded (0.00s)
    highlighting_test.go:544: render mismatch, got
        <pre tabindex="0" class="chroma"><span class="ln">1</span><span class="nf">GET</span> <span class="nn">/foo</span> <span class="kr">HTTP</span><span class="o">/</span><span class="m">1.1</span>
        <span class="ln">2</span><span class="n">Content-Type</span><span class="o">:</span> <span class="l">application/json</span>
        <span class="ln">3</span><span class="n">User-Agent</span><span class="o">:</span> <span class="l">foo</span>
        <span class="ln">4</span>
        <span class="ln">5</span><span class="p">{</span>
        <span class="ln">6</span>  <span class="nt">&#34;hello&#34;</span><span class="p">:</span> <span class="s2">&#34;world&#34;</span>
        <span class="ln">7</span><span class="p">}</span>
        </pre>
FAIL
FAIL	github.com/yuin/goldmark-highlighting	0.023s
FAIL
```

So I ended up patching highlighting_test.go to filter out `tabindex="0"` so that the tests work with both chroma v0.9.1 and older and v0.9.2 and newer.

And then I see PR #21 which fixes the same problem by updating chroma dependency to v0.9.2.

Anyhow, I do like my solution too as it offers more flexibility, so I thought I would share it here too.  :-)  Cheers!